### PR TITLE
Fixes the issue that the '--version' option not return the expected version value of ion-java.

### DIFF
--- a/src/com/amazon/ion/benchmark/VersionInfo.java
+++ b/src/com/amazon/ion/benchmark/VersionInfo.java
@@ -21,8 +21,8 @@ import java.util.jar.Manifest;
 class VersionInfo {
 
     private static final String MANIFEST_FILE = "META-INF/MANIFEST.MF";
-    private static final String ION_JAVA_PROPERTIES_FILE = "META-INF/maven/com.amazon.ion/ion-java/pom.properties";
-    private static final String ION_JAVA_PROPERTIES_VERSION_KEY = "version";
+    private static final String ION_JAVA_PROPERTIES_FILE = "ion-java.properties";
+    private static final String ION_JAVA_PROPERTIES_VERSION_KEY = "build.version";
     private static final String ION_JAVA_PROJECT_VERSION_ATTRIBUTE = "Ion-Java-Project-Version";
     private static final String CLI_BUILD_TIME_ATTRIBUTE = "Ion-Java-Benchmark-Build-Time";
     private static final String CLI_PROJECT_VERSION_ATTRIBUTE = "Ion-Java-Benchmark-Project-Version";


### PR DESCRIPTION
### Issue #, if available:
N/A

### Description of changes:
The option '--version' of ion-java-benchmark-cli was not functional since the change of ion-java build. This PR fixed the issue to allow the option '--version' returns the correct ion-java version. 

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
